### PR TITLE
[feature-searchList] unittest 코드 iOSCleanArchitecture 는 더이상 없으므로 삭제

### DIFF
--- a/Tests/AppStoreAPIModuleTests/SearchListTests/SearchListViewModelTests.swift
+++ b/Tests/AppStoreAPIModuleTests/SearchListTests/SearchListViewModelTests.swift
@@ -233,7 +233,7 @@ final class TestSearchListUseCase: SearchListUseCaseProtocol {
         .eraseToAnyPublisher()
     }
     
-    func selectSearchKeywordBind(searchKeyword: String) -> AnyPublisher<[iOSCleanArchitecture.SearchListEntity], any Error> {
+    func selectSearchKeywordBind(searchKeyword: String) -> AnyPublisher<[SearchListEntity], any Error> {
         if testFailBind {
             return Fail(error: NSError(domain: "Test", code: -1, userInfo: [NSLocalizedDescriptionKey: "Bind Error"]))
                 .eraseToAnyPublisher()


### PR DESCRIPTION
unittest 코드 iOSCleanArchitecture 는 더이상 없으므로 삭제